### PR TITLE
Fix moon check deprecation warnings for moonbit 0.10.7

### DIFF
--- a/src/lower/asm_ast.mbt
+++ b/src/lower/asm_ast.mbt
@@ -3,7 +3,7 @@ pub(all) enum Type {
   ConstTy(@parse.ConstantSize)
   ArrayTy(@parse.ConstantSize)
   LabelTy
-} derive (Show, Eq)
+} derive (Debug, Eq)
 
 pub(all) enum TypedExpr {
   Const(
@@ -15,12 +15,12 @@ pub(all) enum TypedExpr {
   Ident(name~: String, ty~: Type)
   Unary(op~: @parse.UnaryOp, expr~: TypedExpr, ty~: Type)
   Binary(op~: @parse.BinaryOp, lhs~: TypedExpr, rhs~: TypedExpr, ty~: Type)
-} derive (Show)
+} derive (Debug)
 
 pub(all) enum AsmTableLine {
   Data(data~: Array[TypedExpr], comment~: Ref[String])
   Comment(String)
-} derive (Show)
+} derive (Debug)
 
 pub(all) struct AsmTable {
   name: String
@@ -29,7 +29,7 @@ pub(all) struct AsmTable {
   size: Int
   elem_size: @parse.ConstantSize
   items_count: Int
-} derive (Show)
+} derive (Debug)
 
 pub(all) enum AsmAddressingMode {
   Accumulator
@@ -45,7 +45,7 @@ pub(all) enum AsmAddressingMode {
   Indirect(TypedExpr)
   IndexedIndirect(TypedExpr)
   IndirectIndexed(TypedExpr)
-} derive (Show)
+} derive (Debug)
 
 pub(all) enum AsmItem {
   Label(String)
@@ -53,12 +53,12 @@ pub(all) enum AsmItem {
   JumpEngine(jump_table~: Array[String])
   If(cond~: @parse.OpCode, then~: Array[AsmItem], otherwise~: Array[AsmItem]?, comment~: String?)
   Comment(String)
-} derive (Show)
+} derive (Debug)
 
 pub(all) struct BasicBlockLink {
   bb: BasicBlock
   is_fallthrough: Bool
-} derive (Show)
+} derive (Debug)
 
 pub(all) struct BasicBlock {
   id: Int
@@ -68,7 +68,7 @@ pub(all) struct BasicBlock {
   successors: Array[BasicBlockLink]
   mut is_subroutine_entry: Bool
   mut subroutine: AsmSubroutine?
-} derive (Show)
+} derive (Debug)
 
 pub(all) struct AsmSubroutine {
   name: String
@@ -76,13 +76,13 @@ pub(all) struct AsmSubroutine {
   entry: BasicBlock
   mut exit: BasicBlock
   internal_labels: Set[String]
-} derive (Show)
+} derive (Debug)
 
 // subroutines with a flat array of items instead of basic blocks
 pub(all) struct AsmFlatSubroutine {
   name: String
   items: Array[AsmItem]
-} derive (Show)
+} derive (Debug)
 
 pub fn TypedExpr::ty(self: TypedExpr) -> Type {
   match self {

--- a/src/lower/lower.mbt
+++ b/src/lower/lower.mbt
@@ -12,9 +12,9 @@ pub(all) struct AsmLowering {
   bb_by_label: Map[String, BasicBlock]
   subroutines: Array[AsmSubroutine]
   flat_subroutines: Array[AsmFlatSubroutine]
-} derive (Show)
+} derive (Debug)
 
-pub suberror LoweringError { LoweringError(String) } derive(Show)
+pub suberror LoweringError { LoweringError(String) } derive(Debug)
 
 pub fn AsmLowering::new(items: Array[@parse.SourceItem]) -> AsmLowering {
   {
@@ -23,9 +23,9 @@ pub fn AsmLowering::new(items: Array[@parse.SourceItem]) -> AsmLowering {
     defines: {},
     tables: [],
     table_offset: 0, // in bytes
-    jump_target_labels: Set::new(),
+    jump_target_labels: Set([]),
     tables_by_label: {},
-    targets: { jump_targets: Set::new(), subroutines: Set::new(), externals: Set::new() },
+    targets: { jump_targets: Set([]), subroutines: Set([]), externals: Set([]) },
     basic_blocks: [],
     bb_by_label: {},
     subroutines: [],
@@ -63,7 +63,7 @@ fn AsmLowering::detect_table(self: AsmLowering, name: String, index: Int) -> Asm
           data.push(self.type_expr(arg))
         }
 
-        lines.push(Data(data~, comment=Ref::new("")))
+        lines.push(Data(data~, comment=Ref("")))
       }
       Comment(comment~, is_inline~) => {
         if is_inline {
@@ -193,7 +193,7 @@ fn AsmLowering::collect_instructions(self: AsmLowering) -> Unit raise LoweringEr
 
     match item {
       Label(name) => {
-        if not(self.tables_by_label.contains(name)) {
+        if !(self.tables_by_label.contains(name)) {
           // this label is a jump target if it's not a table label
           
           self.lowered.push(Label(name))
@@ -213,7 +213,7 @@ fn AsmLowering::collect_instructions(self: AsmLowering) -> Unit raise LoweringEr
                 for arg in args {
                   match arg {
                     Ident(label) => {
-                      if not(self.jump_target_labels.contains(label)) {
+                      if !(self.jump_target_labels.contains(label)) {
                         raise LoweringError("Unknown label in jump table")
                       }
 
@@ -269,13 +269,13 @@ fn AsmLowering::collect_instructions(self: AsmLowering) -> Unit raise LoweringEr
         }
       }
       Comment(comment~, is_inline=false) => {
-        if not(inside_table) {
+        if !(inside_table) {
           self.lowered.push(Comment(comment))
         }
       }
       Directive(name="db" | "dw" as name, args~) => {
-        if not(inside_table) {
-          raise LoweringError("Raw data in code detected: \{name} \{args}")
+        if !(inside_table) {
+          raise LoweringError("Raw data in code detected: \{name} \{Repr(args)}")
         }
       }
       _ => ()
@@ -289,7 +289,7 @@ pub(all) struct JumpTargets {
   jump_targets: Set[String]
   subroutines: Set[String]
   externals: Set[String]
-} derive (Show)
+} derive (Debug)
 
 fn AsmLowering::collect_jump_targets(self: AsmLowering) -> Unit {
   for item in self.lowered {
@@ -448,11 +448,11 @@ fn AsmLowering::collect_basic_blocks(self: AsmLowering) -> Unit raise LoweringEr
   }
 
   fn connect(a: BasicBlock, b: BasicBlock, is_fallthrough: Bool) -> Unit {
-    if not(a.successors.iter().any(fn(link) { link.bb.id == b.id })) {
+    if !(a.successors.iter().any(fn(link) { link.bb.id == b.id })) {
       a.successors.push({ bb: b, is_fallthrough })
     }
 
-    if not(b.predecessors.iter().any(fn(link) { link.bb.id == a.id })) {
+    if !(b.predecessors.iter().any(fn(link) { link.bb.id == a.id })) {
       b.predecessors.push({ bb: a, is_fallthrough })
     }
   }
@@ -472,7 +472,7 @@ fn AsmLowering::collect_basic_blocks(self: AsmLowering) -> Unit raise LoweringEr
             connect(bb, target_bb, false)
           }
           None => {
-            if not(label.has_prefix("__")) { // allow special labels
+            if !(label.has_prefix("__")) { // allow special labels
               raise LoweringError("Unknown jump target: \{label}")
             }
           }
@@ -485,7 +485,7 @@ fn AsmLowering::collect_basic_blocks(self: AsmLowering) -> Unit raise LoweringEr
               connect(bb, target_bb, false)
             }
             None => {
-              if not(label.has_prefix("__")) { // allow special labels
+              if !(label.has_prefix("__")) { // allow special labels
                 raise LoweringError("Unknown jump target: \{label}")
               }
             }
@@ -515,7 +515,7 @@ fn AsmLowering::rewrite_bb(self: AsmLowering, bb: BasicBlock, visited: Set[Int])
           blocks: [bb],
           entry: bb,
           exit: bb,
-          internal_labels: Set::new(),
+          internal_labels: Set([]),
         }
 
         let mut i = bb.id + 1
@@ -562,7 +562,7 @@ pub fn AsmLowering::is_subroutine_label(self: AsmLowering, label: String) -> Boo
 
 fn AsmLowering::collect_subroutines(self: AsmLowering) -> Unit raise LoweringError {
   let components = self.collect_connected_components()
-  let visited = Set::new()
+  let visited = Set([])
 
   for component in components {
     for bb in component {
@@ -575,10 +575,10 @@ fn BasicBlock::dfs(self: BasicBlock, visited: Set[Int]) -> Array[BasicBlock] {
   let stack = [self]
   let blocks = []
 
-  while not(stack.is_empty()) {
+  while !(stack.is_empty()) {
     let bb = stack.pop().unwrap()
 
-    if not(visited.contains(bb.id)) {
+    if !(visited.contains(bb.id)) {
       visited.add(bb.id)
       blocks.push(bb)
 
@@ -594,10 +594,10 @@ fn BasicBlock::dfs(self: BasicBlock, visited: Set[Int]) -> Array[BasicBlock] {
 
 fn AsmLowering::collect_connected_components(self: AsmLowering) -> Array[Array[BasicBlock]] {
   let components = []
-  let visited = Set::new()
+  let visited = Set([])
 
   for bb in self.basic_blocks {
-    if not(visited.contains(bb.id)) {
+    if !(visited.contains(bb.id)) {
       let blocks = bb.dfs(visited)
       components.push(blocks)
     }
@@ -664,11 +664,11 @@ fn negate(cond: @parse.OpCode) -> @parse.OpCode raise LoweringError {
 
 fn AsmLowering::recognize_control_flow(self: AsmLowering, sub: AsmSubroutine) -> AsmFlatSubroutine raise LoweringError {
   let items = sub.blocks.map(fn(bb) { bb.items }).flatten()
-  let labels = Set::new()
+  let labels = Set([])
   let new_items = []
   let stack: Array[ControlFlowStackEntry] = []
-  let loop_labels = Set::new()
-  let unconditional_jump_labels = Set::new()
+  let loop_labels = Set([])
+  let unconditional_jump_labels = Set([])
 
   // detect backward jumps
   for item in items {
@@ -758,7 +758,7 @@ fn AsmLowering::recognize_control_flow(self: AsmLowering, sub: AsmSubroutine) ->
             otherwise=None,
             comment=comment,
           ))
-        } else if not(loop_labels.contains(label)) {
+        } else if !(loop_labels.contains(label)) {
         // if this is not a loop
           let entry = {
             exit_label: label,

--- a/src/lower/lower.mbt
+++ b/src/lower/lower.mbt
@@ -193,7 +193,7 @@ fn AsmLowering::collect_instructions(self: AsmLowering) -> Unit raise LoweringEr
 
     match item {
       Label(name) => {
-        if !(self.tables_by_label.contains(name)) {
+        if !self.tables_by_label.contains(name) {
           // this label is a jump target if it's not a table label
           
           self.lowered.push(Label(name))
@@ -213,7 +213,7 @@ fn AsmLowering::collect_instructions(self: AsmLowering) -> Unit raise LoweringEr
                 for arg in args {
                   match arg {
                     Ident(label) => {
-                      if !(self.jump_target_labels.contains(label)) {
+                      if !self.jump_target_labels.contains(label) {
                         raise LoweringError("Unknown label in jump table")
                       }
 
@@ -269,12 +269,12 @@ fn AsmLowering::collect_instructions(self: AsmLowering) -> Unit raise LoweringEr
         }
       }
       Comment(comment~, is_inline=false) => {
-        if !(inside_table) {
+        if !inside_table {
           self.lowered.push(Comment(comment))
         }
       }
       Directive(name="db" | "dw" as name, args~) => {
-        if !(inside_table) {
+        if !inside_table {
           raise LoweringError("Raw data in code detected: \{name} \{Repr(args)}")
         }
       }
@@ -448,11 +448,11 @@ fn AsmLowering::collect_basic_blocks(self: AsmLowering) -> Unit raise LoweringEr
   }
 
   fn connect(a: BasicBlock, b: BasicBlock, is_fallthrough: Bool) -> Unit {
-    if !(a.successors.iter().any(fn(link) { link.bb.id == b.id })) {
+    if !a.successors.iter().any(fn(link) { link.bb.id == b.id }) {
       a.successors.push({ bb: b, is_fallthrough })
     }
 
-    if !(b.predecessors.iter().any(fn(link) { link.bb.id == a.id })) {
+    if !b.predecessors.iter().any(fn(link) { link.bb.id == a.id }) {
       b.predecessors.push({ bb: a, is_fallthrough })
     }
   }
@@ -472,7 +472,7 @@ fn AsmLowering::collect_basic_blocks(self: AsmLowering) -> Unit raise LoweringEr
             connect(bb, target_bb, false)
           }
           None => {
-            if !(label.has_prefix("__")) { // allow special labels
+            if !label.has_prefix("__") { // allow special labels
               raise LoweringError("Unknown jump target: \{label}")
             }
           }
@@ -485,7 +485,7 @@ fn AsmLowering::collect_basic_blocks(self: AsmLowering) -> Unit raise LoweringEr
               connect(bb, target_bb, false)
             }
             None => {
-              if !(label.has_prefix("__")) { // allow special labels
+              if !label.has_prefix("__") { // allow special labels
                 raise LoweringError("Unknown jump target: \{label}")
               }
             }
@@ -575,10 +575,10 @@ fn BasicBlock::dfs(self: BasicBlock, visited: Set[Int]) -> Array[BasicBlock] {
   let stack = [self]
   let blocks = []
 
-  while !(stack.is_empty()) {
+  while !stack.is_empty() {
     let bb = stack.pop().unwrap()
 
-    if !(visited.contains(bb.id)) {
+    if !visited.contains(bb.id) {
       visited.add(bb.id)
       blocks.push(bb)
 
@@ -597,7 +597,7 @@ fn AsmLowering::collect_connected_components(self: AsmLowering) -> Array[Array[B
   let visited = Set([])
 
   for bb in self.basic_blocks {
-    if !(visited.contains(bb.id)) {
+    if !visited.contains(bb.id) {
       let blocks = bb.dfs(visited)
       components.push(blocks)
     }
@@ -758,7 +758,7 @@ fn AsmLowering::recognize_control_flow(self: AsmLowering, sub: AsmSubroutine) ->
             otherwise=None,
             comment=comment,
           ))
-        } else if !(loop_labels.contains(label)) {
+        } else if !loop_labels.contains(label) {
         // if this is not a loop
           let entry = {
             exit_label: label,

--- a/src/lower/moon.pkg.json
+++ b/src/lower/moon.pkg.json
@@ -1,6 +1,7 @@
 {
     "is-main": false,
     "import": [
-      "nathsou/smb/parse"
+      "nathsou/smb/parse",
+      "moonbitlang/core/debug"
     ]
   }

--- a/src/main/main.mbt
+++ b/src/main/main.mbt
@@ -55,11 +55,11 @@ let output_dir: String = "codegen"
 let lib_output_dir: String = "\{output_dir}/lib"
 
 fn run() -> Unit raise Error {
-  if !(@fs.path_exists(output_dir)) {
+  if !@fs.path_exists(output_dir) {
     @fs.create_dir(output_dir)
   }
 
-  if !(@fs.path_exists(lib_output_dir)) {
+  if !@fs.path_exists(lib_output_dir) {
     @fs.create_dir(lib_output_dir)
   }
 

--- a/src/main/main.mbt
+++ b/src/main/main.mbt
@@ -4,7 +4,7 @@ suberror PipelineError {
   LexerError(@parse.LexerError)
   ParserError(@parse.ParserError)
   LoweringError(@lower.LoweringError)
-} derive(Show)
+} derive(Debug)
 
 fn read_rom() -> String raise PipelineError {
   try @fs.read_file_to_string("src/smb.asm") catch {
@@ -55,17 +55,17 @@ let output_dir: String = "codegen"
 let lib_output_dir: String = "\{output_dir}/lib"
 
 fn run() -> Unit raise Error {
-  if not(@fs.path_exists(output_dir)) {
+  if !(@fs.path_exists(output_dir)) {
     @fs.create_dir(output_dir)
   }
 
-  if not(@fs.path_exists(lib_output_dir)) {
+  if !(@fs.path_exists(lib_output_dir)) {
     @fs.create_dir(lib_output_dir)
   }
 
   try transpile() catch {
       err => {
-          println(err)
+          println(@debug.to_string(err))
       }
   } noraise {
       tr => {

--- a/src/main/moon.pkg.json
+++ b/src/main/moon.pkg.json
@@ -4,6 +4,7 @@
     "nathsou/smb/parse",
     "nathsou/smb/lower",
     "moonbitlang/x/fs",
+    "moonbitlang/core/debug",
     "nathsou/smb/transpile"
   ]
 }

--- a/src/parse/lex.mbt
+++ b/src/parse/lex.mbt
@@ -7,7 +7,7 @@ pub(all) struct Lexer {
 pub suberror LexerError {
   UnexpectedChar(char~: Char, index~: Int)
   InvalidConstant(lexeme~: String, base~: ConstantBase)
-} derive(Show)
+} derive(Debug)
 
 fn is_whitespace(c: Char) -> Bool {
   match c {
@@ -106,7 +106,7 @@ fn Lexer::parse_constant(self: Lexer, base~: ConstantBase) -> LexerResult {
   let value = match (lexeme, base) {
     ("0b", Hexadecimal) => 11 // https://github.com/moonbitlang/core/issues/2006
     _ => {
-      try @strconv.parse_int(lexeme, base=base.to_int()) catch {
+      try @string.parse_int(lexeme, base=base.to_int()) catch {
         _ => return Grr(InvalidConstant(lexeme~, base~))
       } noraise {
         value => value
@@ -329,7 +329,7 @@ fn Lexer::next(self: Lexer) -> LexerResult {
       let mut is_inline = false
 
       while i >= 0 && self.input[i] != '\n' {
-        if not(is_whitespace(self.input[i].to_char().unwrap())) {
+        if !(is_whitespace(self.input[i].to_char().unwrap())) {
           is_inline = true
           break
         }

--- a/src/parse/lex.mbt
+++ b/src/parse/lex.mbt
@@ -329,7 +329,7 @@ fn Lexer::next(self: Lexer) -> LexerResult {
       let mut is_inline = false
 
       while i >= 0 && self.input[i] != '\n' {
-        if !(is_whitespace(self.input[i].to_char().unwrap())) {
+        if !is_whitespace(self.input[i].to_char().unwrap()) {
           is_inline = true
           break
         }

--- a/src/parse/moon.pkg.json
+++ b/src/parse/moon.pkg.json
@@ -1,1 +1,6 @@
-{}
+{
+  "import": [
+    "moonbitlang/core/debug",
+    "moonbitlang/core/string"
+  ]
+}

--- a/src/parse/parse.mbt
+++ b/src/parse/parse.mbt
@@ -8,7 +8,7 @@ pub suberror ParserError {
   UnexpectedToken(expected~: Token, received~: Token)
   ExpectedExpr(Token)
   Unreachable(String)
-} derive(Show)
+} derive(Debug)
 
 pub fn Parser::new(tokens: Array[Token]) -> Parser {
   { tokens, index: 0, defines: {} }
@@ -100,7 +100,7 @@ fn Parser::parse_directive_args(self: Parser) -> Array[SourceExpr] raise ParserE
   while true {
     let expr = self.parse_expr()
     args.push(expr)
-    if not(self.consumes(Comma)) {
+    if !(self.consumes(Comma)) {
       break
     }
   }
@@ -204,7 +204,7 @@ fn Parser::parse_inst(self: Parser) -> SourceItem raise ParserError {
       self.advance()
       Comment(comment~, is_inline~)
     }
-    _ => raise Unreachable("Expected instruction, got: \{token}")
+    _ => raise Unreachable("Expected instruction, got: \{Repr(token)}")
   }
 }
 

--- a/src/parse/parse.mbt
+++ b/src/parse/parse.mbt
@@ -100,7 +100,7 @@ fn Parser::parse_directive_args(self: Parser) -> Array[SourceExpr] raise ParserE
   while true {
     let expr = self.parse_expr()
     args.push(expr)
-    if !(self.consumes(Comma)) {
+    if !self.consumes(Comma) {
       break
     }
   }

--- a/src/parse/source_ast.mbt
+++ b/src/parse/source_ast.mbt
@@ -2,18 +2,18 @@
 
 pub(all) enum UnaryOp {
   GetLowByte; GetHighByte
-} derive (Show)
+} derive (Debug)
 
 pub(all) enum BinaryOp {
   Add; Sub
-} derive (Show)
+} derive (Debug)
 
 pub(all) enum SourceExpr {
   Const(base~: ConstantBase, value~: Int, size~: ConstantSize)
   Ident(String)
   Unary(op~: UnaryOp, expr~: SourceExpr)
   Binary(op~: BinaryOp, lhs~: SourceExpr, rhs~: SourceExpr)
-} derive (Show)
+} derive (Debug)
 
 // https://www.nesdev.org/wiki/CPU_addressing_modes
 pub(all) enum SourceAddressingMode {
@@ -27,7 +27,7 @@ pub(all) enum SourceAddressingMode {
   Indirect(addr~: SourceExpr)
   IndexedIndirect(addr~: SourceExpr) // (d,x)
   IndirectIndexed(addr~: SourceExpr) // (d),y
-} derive (Show)
+} derive (Debug)
 
 pub(all) enum SourceItem {
   Label(String)
@@ -35,4 +35,4 @@ pub(all) enum SourceItem {
   Define(name~: String, rhs~: SourceExpr)
   Directive(name~: String, args~: Array[SourceExpr])
   Comment(comment~: String, is_inline~: Bool)
-} derive (Show)
+} derive (Debug)

--- a/src/parse/token.mbt
+++ b/src/parse/token.mbt
@@ -3,15 +3,15 @@ pub(all) enum OpCode {
   CLD; CLI; CLV; CMP; CPX; CPY; DEC; DEX; DEY; EOR; INC; INX; INY; JMP
   JSR; LDA; LDX; LDY; LSR; NOP; ORA; PHA; PHP; PLA; PLP; ROL; ROR; RTI
   RTS; SBC; SEC; SED; SEI; STA; STX; STY; TAX; TAY; TSX; TXA; TXS; TYA
-} derive (Show, Eq, Hash)
+} derive (Debug, Eq, Hash)
 
 pub(all) enum ConstantBase {
   Binary; Decimal; Hexadecimal
-} derive (Show, Eq)
+} derive (Debug, Eq)
 
 pub(all) enum ConstantSize {
   Byte; Word
-} derive (Show, Eq)
+} derive (Debug, Eq)
 
 enum Token {
   Comment(comment~: String, is_inline~: Bool)
@@ -29,7 +29,7 @@ enum Token {
   RightParen
   LeftChevron
   RightChevron
-} derive (Show, Eq)
+} derive (Debug, Eq)
 
 fn ConstantBase::to_int(self: ConstantBase) -> Int {
   match self {

--- a/src/transpile/moon.pkg.json
+++ b/src/transpile/moon.pkg.json
@@ -3,6 +3,7 @@
     "import": [
       "nathsou/smb/parse",
       "nathsou/smb/lower",
-      "moonbitlang/x/fs"
+      "moonbitlang/x/fs",
+      "moonbitlang/core/debug"
     ]
   }

--- a/src/transpile/transpile.mbt
+++ b/src/transpile/transpile.mbt
@@ -99,7 +99,7 @@ fn show_expr(expr: @lower.TypedExpr) -> String {
   }
 }
 
-pub(all) suberror EmitterError { EmitterError(String) } derive(Show)
+pub(all) suberror EmitterError { EmitterError(String) } derive(Debug)
 
 fn Emitter::emit_constants_h(self: Emitter, low: @lower.AsmLowering) -> Unit {
   self.emit("#ifndef SMB_CONSTANTS_H")
@@ -187,7 +187,7 @@ fn Emitter::emit_code_h(self: Emitter, low: @lower.AsmLowering) -> Unit {
 
 fn rename_label(label: String) -> String {
   if label.has_suffix("__sub") {
-    label.split("__sub").iter().next().unwrap().to_string()
+    label.split("__sub").iter().next().unwrap().to_owned()
   } else {
     label
   }
@@ -328,7 +328,7 @@ fn Emitter::emit_item(self: Emitter, item: @lower.AsmItem, low: @lower.AsmLoweri
         // do not output labels for subroutines
         let is_subroutine_label = low.is_subroutine_label(name);
 
-        if not(is_subroutine_label) {
+        if !(is_subroutine_label) {
           self.emit("\n\{rename_label(name)}:")
         }
       }
@@ -386,7 +386,7 @@ fn Emitter::emit_item(self: Emitter, item: @lower.AsmItem, low: @lower.AsmLoweri
                 "\{target}();"
               }
               (RTS, _) => "return;"
-              _ => "\{op.to_string().to_lower()}\{mode.suffix()}(\{args});"
+              _ => "\{@debug.to_string(op).to_lower()}\{mode.suffix()}(\{args});"
             }
           }
         }

--- a/src/transpile/transpile.mbt
+++ b/src/transpile/transpile.mbt
@@ -328,7 +328,7 @@ fn Emitter::emit_item(self: Emitter, item: @lower.AsmItem, low: @lower.AsmLoweri
         // do not output labels for subroutines
         let is_subroutine_label = low.is_subroutine_label(name);
 
-        if !(is_subroutine_label) {
+        if !is_subroutine_label {
           self.emit("\n\{rename_label(name)}:")
         }
       }


### PR DESCRIPTION
Fixes all 83 warnings reported by `moon check`.

## Clusters fixed
- **`derive(Show)` → `derive(Debug)`** (26 sites across all 8 source files). This also removes the cascade of "Use Debug instead of Show" field-type warnings. Show-dependent call sites now use `\{Repr(...)\}` / `@debug.to_string(...)` instead:
  - `parse.mbt` — token display in parser error
  - `lower.mbt` — raw-data error message
  - `transpile.mbt` — opcode name for generated C code
  - `main.mbt` — pipeline error printing
- **`Set::new()` → `Set([])`** (10 sites)
- **`not(x)` → `!(x)`** (17 sites)
- **`@strconv.parse_int` → `@string.parse_int`** + `string` import
- **`Ref::new("")` → `Ref("")`**
- **`StringView.to_string()` → `.to_owned()`**
- Added `moonbitlang/core/debug` imports to main/lower/transpile/parse packages

## Validation
- `moon check` and `moon build` pass with 0 warnings
- Generated `codegen/` output is byte-identical to before (verified via git diff)
- Fixes were validated in a scratch package before applying